### PR TITLE
DTSPO-261 - update --git-path for flux

### DIFF
--- a/bootstrap/_bootstrap_cmds
+++ b/bootstrap/_bootstrap_cmds
@@ -17,7 +17,7 @@ HELM_OPERATOR_VER="1.1.0"
 
 ### Note Automation cluster Name lookup later
 # CLUSTER_NAME="00"
-flux_repo_list="k8s/environments/${ENVIRONMENT}/cluster-${CLUSTER_NAME}\,k8s/environments/${ENVIRONMENT}/cluster-${CLUSTER_NAME}-overlay\,k8s/environments/${ENVIRONMENT}/common\,k8s/common"
+flux_repo_list="k8s/environments/${ENVIRONMENT}/cluster-${CLUSTER_NAME}\,k8s/environments/${ENVIRONMENT}/cluster-${CLUSTER_NAME}-overlay\,k8s/environments/${ENVIRONMENT}/common\,k8s/environments/${ENVIRONMENT}/common-overlay\,k8s/common"
 
 
 


### PR DESCRIPTION
DTSPO-261 - update --git-path so that the common-overlay directory is picked up by flux

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-161


### Change description ###
updating --git-path list so that flux picks up the new common-overlays directory


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
