### PR TITLE
Added vnet links to central private dns zones

### DIFF
--- a/config/terraform/ss/vars/01-network/demo.tfvars
+++ b/config/terraform/ss/vars/01-network/demo.tfvars
@@ -7,7 +7,13 @@ iaas_subnet_cidr_blocks                = "10.51.96.0/25"
 application_gateway_subnet_cidr_blocks = "10.51.96.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["demo.platform.hmcts.net"]
+private_dns_zones = [
+  "demo.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "nonprod"
 

--- a/config/terraform/ss/vars/01-network/demo.tfvars
+++ b/config/terraform/ss/vars/01-network/demo.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/dev.tfvars
+++ b/config/terraform/ss/vars/01-network/dev.tfvars
@@ -7,7 +7,13 @@ iaas_subnet_cidr_blocks                = "10.145.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.145.32.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["dev.platform.hmcts.net"]
+private_dns_zones = [
+  "dev.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "nonprod"
 

--- a/config/terraform/ss/vars/01-network/dev.tfvars
+++ b/config/terraform/ss/vars/01-network/dev.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/ithc.tfvars
+++ b/config/terraform/ss/vars/01-network/ithc.tfvars
@@ -7,6 +7,12 @@ iaas_subnet_cidr_blocks                = "10.143.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.143.32.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["ithc.platform.hmcts.net"]
+private_dns_zones = [
+  "ithc.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/ithc.tfvars
+++ b/config/terraform/ss/vars/01-network/ithc.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/prod.tfvars
+++ b/config/terraform/ss/vars/01-network/prod.tfvars
@@ -7,6 +7,12 @@ iaas_subnet_cidr_blocks                = "10.144.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.144.32.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["platform.hmcts.net"]
+private_dns_zones = [
+  "platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "prod"

--- a/config/terraform/ss/vars/01-network/prod.tfvars
+++ b/config/terraform/ss/vars/01-network/prod.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "prod"

--- a/config/terraform/ss/vars/01-network/sbox.tfvars
+++ b/config/terraform/ss/vars/01-network/sbox.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "sbox"

--- a/config/terraform/ss/vars/01-network/sbox.tfvars
+++ b/config/terraform/ss/vars/01-network/sbox.tfvars
@@ -7,6 +7,12 @@ iaas_subnet_cidr_blocks                = "10.140.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.140.32.128/25"
 
 private_dns_subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
-private_dns_zones        = ["sandbox.platform.hmcts.net"]
+private_dns_zones = [
+  "sandbox.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "sbox"

--- a/config/terraform/ss/vars/01-network/stg.tfvars
+++ b/config/terraform/ss/vars/01-network/stg.tfvars
@@ -7,6 +7,12 @@ iaas_subnet_cidr_blocks                = "10.142.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.142.32.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["staging.platform.hmcts.net"]
+private_dns_zones = [
+  "staging.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/stg.tfvars
+++ b/config/terraform/ss/vars/01-network/stg.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/test.tfvars
+++ b/config/terraform/ss/vars/01-network/test.tfvars
@@ -7,6 +7,12 @@ iaas_subnet_cidr_blocks                = "10.141.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.141.32.128/25"
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-private_dns_zones        = ["test.platform.hmcts.net"]
+private_dns_zones = [
+  "test.platform.hmcts.net",
+  "privatelink.database.windows.net",
+  "privatelink.blob.core.windows.net",
+  "privatelink.vaultcore.azure.net",
+  "privatelink.datafactory.azure.net"
+]
 
 hub = "nonprod"

--- a/config/terraform/ss/vars/01-network/test.tfvars
+++ b/config/terraform/ss/vars/01-network/test.tfvars
@@ -12,7 +12,8 @@ private_dns_zones = [
   "privatelink.database.windows.net",
   "privatelink.blob.core.windows.net",
   "privatelink.vaultcore.azure.net",
-  "privatelink.datafactory.azure.net"
+  "privatelink.datafactory.azure.net",
+  "privatelink.postgres.database.azure.com"
 ]
 
 hub = "nonprod"


### PR DESCRIPTION
### Change description ###

To support private endpoint DNS in use by the MI Data Platform, vnet links for the below private dns zones added for all environments:

-   privatelink.database.windows.net
-   privatelink.blob.core.windows.net
-   privatelink.vaultcore.azure.net
-   privatelink.datafactory.azure.net
-   privatelink.postgres.database.azure.com

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
