### PR TITLE
Enable Service endpoints and Network Policy Enforcement to support Private Endpoints

### DIFF
--- a/config/terraform/ss/vars/01-network/sbox.tfvars
+++ b/config/terraform/ss/vars/01-network/sbox.tfvars
@@ -6,6 +6,13 @@ aks_01_subnet_cidr_blocks              = "10.140.16.0/20"
 iaas_subnet_cidr_blocks                = "10.140.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.140.32.128/25"
 
+iaas_subnet_service_endpoints          = [
+  "Microsoft.Storage"
+  "Microsoft.KeyVault"
+  "Microsoft.Sql"
+]
+iaas_subnet_enforce_private_link_network_policies = true
+
 private_dns_subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
 private_dns_zones = [
   "sandbox.platform.hmcts.net",

--- a/config/terraform/ss/vars/01-network/sbox.tfvars
+++ b/config/terraform/ss/vars/01-network/sbox.tfvars
@@ -11,7 +11,7 @@ iaas_subnet_service_endpoints          = [
   "Microsoft.KeyVault",
   "Microsoft.Sql"
 ]
-iaas_subnet_enforce_private_link_network_policies = true
+iaas_subnet_enforce_private_link_endpoint_network_policies = true
 
 private_dns_subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
 private_dns_zones = [

--- a/config/terraform/ss/vars/01-network/sbox.tfvars
+++ b/config/terraform/ss/vars/01-network/sbox.tfvars
@@ -7,8 +7,8 @@ iaas_subnet_cidr_blocks                = "10.140.32.0/25"
 application_gateway_subnet_cidr_blocks = "10.140.32.128/25"
 
 iaas_subnet_service_endpoints          = [
-  "Microsoft.Storage"
-  "Microsoft.KeyVault"
+  "Microsoft.Storage",
+  "Microsoft.KeyVault",
   "Microsoft.Sql"
 ]
 iaas_subnet_enforce_private_link_network_policies = true

--- a/terraform/aks/01-network/10-inputs-required.tf
+++ b/terraform/aks/01-network/10-inputs-required.tf
@@ -46,7 +46,7 @@ variable "application_gateway_subnet_cidr_blocks" {
 variable "iaas_subnet_service_endpoints" {
 }
 
-variable "iaas_subnet_enforce_private_link_network_policies" {
+variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
 }
 
 # Remote State

--- a/terraform/aks/01-network/10-inputs-required.tf
+++ b/terraform/aks/01-network/10-inputs-required.tf
@@ -43,12 +43,6 @@ variable "iaas_subnet_cidr_blocks" {
 variable "application_gateway_subnet_cidr_blocks" {
 }
 
-variable "iaas_subnet_service_endpoints" {
-}
-
-variable "iaas_subnet_enforce_private_link_endpoint_network_policies" {
-}
-
 # Remote State
 //variable "hmcts_access_vault" {
 //}

--- a/terraform/aks/01-network/10-inputs-required.tf
+++ b/terraform/aks/01-network/10-inputs-required.tf
@@ -43,6 +43,12 @@ variable "iaas_subnet_cidr_blocks" {
 variable "application_gateway_subnet_cidr_blocks" {
 }
 
+variable "iaas_subnet_service_endpoints" {
+}
+
+variable "iaas_subnet_enforce_private_link_network_policies" {
+}
+
 # Remote State
 //variable "hmcts_access_vault" {
 //}

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=master"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=service_endpoints"
 
   resource_group_name = local.network_resource_group_name
 
@@ -16,9 +16,6 @@ module "network" {
   aks_01_subnet_cidr_blocks                                   = var.aks_01_subnet_cidr_blocks #UK West # Currently both clusters in UK South
   application_gateway_subnet_cidr_blocks                      = var.application_gateway_subnet_cidr_blocks
   iaas_subnet_cidr_blocks                                     = var.iaas_subnet_cidr_blocks
-
-  iaas_subnet_service_endpoints                               = flatten([var.iaas_subnet_service_endpoints])
-  iaas_subnet_enforce_private_link_endpoint_network_policies  = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 
   tags = local.common_tags
 }

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=master"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=service-endpoints"
 
   resource_group_name = local.network_resource_group_name
 

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -17,7 +17,7 @@ module "network" {
   application_gateway_subnet_cidr_blocks                    = var.application_gateway_subnet_cidr_blocks
   iaas_subnet_cidr_blocks                                   = var.iaas_subnet_cidr_blocks
 
-  iaas_subnet_service_endpoints                             = var.iaas_subnet_service_endpoints
+  iaas_subnet_service_endpoints                             = flatten([var.iaas_subnet_service_endpoints])
   iaas_subnet_enforce_private_link_network_policies         = var.iaas_subnet_enforce_private_link_network_policies
 
   tags = local.common_tags

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=service_endpoints"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=service-endpoints"
 
   resource_group_name = local.network_resource_group_name
 

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -12,13 +12,13 @@ module "network" {
   project               = var.project
   service_shortname     = var.service_shortname
 
-  aks_00_subnet_cidr_blocks                                 = var.aks_00_subnet_cidr_blocks #UK South
-  aks_01_subnet_cidr_blocks                                 = var.aks_01_subnet_cidr_blocks #UK West # Currently both clusters in UK South
-  application_gateway_subnet_cidr_blocks                    = var.application_gateway_subnet_cidr_blocks
-  iaas_subnet_cidr_blocks                                   = var.iaas_subnet_cidr_blocks
+  aks_00_subnet_cidr_blocks                                   = var.aks_00_subnet_cidr_blocks #UK South
+  aks_01_subnet_cidr_blocks                                   = var.aks_01_subnet_cidr_blocks #UK West # Currently both clusters in UK South
+  application_gateway_subnet_cidr_blocks                      = var.application_gateway_subnet_cidr_blocks
+  iaas_subnet_cidr_blocks                                     = var.iaas_subnet_cidr_blocks
 
-  iaas_subnet_service_endpoints                             = flatten([var.iaas_subnet_service_endpoints])
-  iaas_subnet_enforce_private_link_network_policies         = var.iaas_subnet_enforce_private_link_network_policies
+  iaas_subnet_service_endpoints                               = flatten([var.iaas_subnet_service_endpoints])
+  iaas_subnet_enforce_private_link_endpoint_network_policies  = var.iaas_subnet_enforce_private_link_endpoint_network_policies
 
   tags = local.common_tags
 }

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -12,10 +12,13 @@ module "network" {
   project               = var.project
   service_shortname     = var.service_shortname
 
-  aks_00_subnet_cidr_blocks              = var.aks_00_subnet_cidr_blocks #UK South
-  aks_01_subnet_cidr_blocks              = var.aks_01_subnet_cidr_blocks #UK West # Currently both clusters in UK South
-  application_gateway_subnet_cidr_blocks = var.application_gateway_subnet_cidr_blocks
-  iaas_subnet_cidr_blocks                = var.iaas_subnet_cidr_blocks
+  aks_00_subnet_cidr_blocks                                 = var.aks_00_subnet_cidr_blocks #UK South
+  aks_01_subnet_cidr_blocks                                 = var.aks_01_subnet_cidr_blocks #UK West # Currently both clusters in UK South
+  application_gateway_subnet_cidr_blocks                    = var.application_gateway_subnet_cidr_blocks
+  iaas_subnet_cidr_blocks                                   = var.iaas_subnet_cidr_blocks
+
+  iaas_subnet_service_endpoints                             = var.iaas_subnet_service_endpoints
+  iaas_subnet_enforce_private_link_network_policies         = var.iaas_subnet_enforce_private_link_network_policies
 
   tags = local.common_tags
 }

--- a/terraform/aks/01-network/20-network.tf
+++ b/terraform/aks/01-network/20-network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "git::https://github.com/hmcts/aks-module-network.git?ref=service-endpoints"
+  source = "git::https://github.com/hmcts/aks-module-network.git?ref=master"
 
   resource_group_name = local.network_resource_group_name
 


### PR DESCRIPTION

### Change description ###

Adding support for service endpoints and enforcing endpoint network policies. This is required to support the use of private endpoints by MI Data Platform.

The Terraform azurerm_subnet resource provider requires 'enforce_private_link_endpoint_network_policies' set to 'true' to deploy a private endpoint on a given subnet.

Network module already updated in [this PR to](https://github.com/hmcts/aks-module-network/pull/5) support the change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
